### PR TITLE
Add builtin support for well-known projects/frameworks

### DIFF
--- a/src/crufty.rs
+++ b/src/crufty.rs
@@ -1,3 +1,4 @@
+pub mod artifact_type;
 pub mod cleaner;
 pub mod cli;
 pub mod estimator;

--- a/src/crufty/artifact_type.rs
+++ b/src/crufty/artifact_type.rs
@@ -1,0 +1,21 @@
+#[derive(Debug, Clone)]
+#[allow(dead_code)]
+pub enum ArtifactType {
+  Rust,
+  Scala,
+  Custom { pattern: &'static str },
+}
+
+pub fn builtin() -> [ArtifactType; 2] {
+  [ArtifactType::Rust, ArtifactType::Scala]
+}
+
+impl ArtifactType {
+  pub fn pattern(&self) -> &'static str {
+    match self {
+      ArtifactType::Rust => "**/target",
+      ArtifactType::Scala => "**/target",
+      ArtifactType::Custom { pattern } => pattern,
+    }
+  }
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,5 +1,6 @@
 use clap::Parser;
 use console::{style, Term};
+use crufty::artifact_type;
 use crufty::cleaner::{self, CleanupResult};
 use crufty::cli::{Cli, Commands};
 use crufty::estimator::{estimate, total_size};
@@ -34,7 +35,7 @@ fn scan() -> io::Result<()> {
     .write_line(&format!("[+] Scanning: {}", style(path.display()).bold()))?;
 
   let spinner = ui::create_spinner("collecting artifacts");
-  let mut artifacts = fetch_artifacts(&path);
+  let mut artifacts = fetch_artifacts(&path, artifact_type::builtin().to_vec());
   spinner.finish_and_clear();
 
   term.write_line("")?;
@@ -82,7 +83,7 @@ fn clean() -> io::Result<()> {
   let path = env::current_dir()?;
 
   let spinner = ui::create_spinner("collecting artifacts");
-  let mut artifacts = fetch_artifacts(&path);
+  let mut artifacts = fetch_artifacts(&path, artifact_type::builtin().to_vec());
   spinner.finish_and_clear();
 
   if artifacts.is_empty() {


### PR DESCRIPTION
Include support for:

* Rust projects (cargo)
* Scala (sbt)

Make the code easy to extend it with other languages and frameworks in the future

Closes https://github.com/EncodePanda/crufty/issues/1